### PR TITLE
Fix non-strict weight loading, correct parameter counts, add quickstart notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,12 @@ model:
 
 ## Examples
 
-See the [`examples/`](examples/) directory:
+Start with the notebook — install, detect, visualize, and inspect the raw model output in
+one pass:
+
+- [`notebooks/quickstart.ipynb`](notebooks/quickstart.ipynb)
+
+Or the standalone scripts in [`examples/`](examples/):
 
 - [`detect_image.py`](examples/detect_image.py) — run detection on a single image
 - [`detect_video.py`](examples/detect_video.py) — run detection on a video file
@@ -143,9 +148,12 @@ See the [`examples/`](examples/) directory:
 
 | Model | Params | Input | mAP (COCO val) |
 |---|---|---|---|
-| YOLO-NAS S | ~12M | 640 | 47.5 |
-| YOLO-NAS M | ~31M | 640 | 51.5 |
-| YOLO-NAS L | ~44M | 640 | 52.2 |
+| YOLO-NAS S | 19.05M | 640 | 47.5 |
+| YOLO-NAS M | 51.18M | 640 | 51.5 |
+| YOLO-NAS L | 66.98M | 640 | 52.2 |
+
+Parameter counts are measured with `sum(p.numel() for p in model.parameters())`. The mAP
+column is Deci's published figure, which this project has not independently re-measured.
 
 ## Development
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,6 +61,6 @@ load directly with only DDP/EMA prefix stripping.
 
 | Variant | `concat_intermediates` | Head `width_mult` | Params |
 |---|---|---|---|
-| S | False everywhere | 0.5 | ~12M |
-| M | True in stages 1-3 | 0.75 | ~31M |
-| L | True everywhere | 1.0 | ~44M |
+| S | False everywhere | 0.5 | 19.05M |
+| M | True in stages 1-3 | 0.75 | 51.18M |
+| L | True everywhere | 1.0 | 66.98M |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -66,6 +66,6 @@ pred_bboxes, pred_scores = model(x)
 
 | Model | Params | mAP (COCO val) |
 |---|---|---|
-| `yolo_nas_s` | ~12M | 47.5 |
-| `yolo_nas_m` | ~31M | 51.5 |
-| `yolo_nas_l` | ~44M | 52.2 |
+| `yolo_nas_s` | 19.05M | 47.5 |
+| `yolo_nas_m` | 51.18M | 51.5 |
+| `yolo_nas_l` | 66.98M | 52.2 |

--- a/docs/guides/extending.md
+++ b/docs/guides/extending.md
@@ -88,8 +88,21 @@ from modern_yolonas.model import YoloNAS
 model = YoloNAS.from_config("yolo_nas_s", num_classes=5)
 ```
 
-Note: when changing `num_classes`, pretrained weights for the classification
-heads won't match (different tensor shapes). Load with `strict=False`:
+When changing `num_classes`, the pretrained classification heads no longer match
+(different tensor shapes). The preferred way to handle this is `transfer_to()`,
+which loads the backbone and neck **strictly** and then swaps in freshly
+initialised heads:
+
+```python
+from modern_yolonas.weights import transfer_to
+
+model = transfer_to("yolo_nas_s", num_classes=5)
+```
+
+Because the pretrained part is loaded strictly, nothing can be silently skipped.
+
+The alternative is a partial load, which keeps every tensor whose shape matches
+the model and leaves the reshaped heads at their initial values:
 
 ```python
 from modern_yolonas.weights import load_pretrained
@@ -97,3 +110,7 @@ from modern_yolonas.weights import load_pretrained
 model = YoloNAS.from_config("yolo_nas_s", num_classes=5)
 load_pretrained(model, "yolo_nas_s", strict=False)
 ```
+
+Prefer `transfer_to()` unless you specifically need the partial-load behaviour — a
+non-strict load will also quietly tolerate a checkpoint that does not belong to
+this architecture at all.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ A clean, minimal Python reimplementation of [YOLO-NAS](https://github.com/Deci-A
 - **CLI** — `yolonas detect`, `yolonas train`, `yolonas export`, `yolonas eval`
 - **ONNX / OpenVINO export** — including Frigate-compatible graph surgery
 - **Training** — full training loop with DDP, AMP, EMA, cosine LR
-- **All 3 variants** — S (~12M), M (~31M), L (~44M)
+- **All 3 variants** — S (19.05M), M (51.18M), L (66.98M)
 
 ## Quick install
 

--- a/notebooks/quickstart.ipynb
+++ b/notebooks/quickstart.ipynb
@@ -46,11 +46,7 @@
    "cell_type": "markdown",
    "id": "install-md",
    "metadata": {},
-   "source": [
-    "## 1. Install\n",
-    "\n",
-    "Requires **Python 3.13+**. Uncomment whichever line matches your setup."
-   ]
+   "source": "## 1. Install\n\nRequires **Python 3.10+**. Uncomment whichever line matches your setup."
   },
   {
    "cell_type": "code",

--- a/notebooks/quickstart.ipynb
+++ b/notebooks/quickstart.ipynb
@@ -1,0 +1,410 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# modern-yolonas — Quickstart\n",
+    "\n",
+    "A clean, minimal reimplementation of [YOLO-NAS](https://github.com/Deci-AI/super-gradients)\n",
+    "object detection. No factory patterns, no registries, no OmegaConf — just PyTorch.\n",
+    "\n",
+    "This notebook covers, end to end:\n",
+    "\n",
+    "1. Installing the package\n",
+    "2. Detecting objects in an image with the high-level `Detector` API\n",
+    "3. Visualizing the result inline\n",
+    "4. Dropping down to the raw model to see what the network actually outputs\n",
+    "5. Exporting to ONNX / OpenVINO for deployment\n",
+    "\n",
+    "Runs on CPU. A GPU makes it faster but is not required."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "licence-warning",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## ⚠️ Read this before you use the pretrained weights\n",
+    "\n",
+    "**The code in this library is MIT. The pretrained COCO weights are not.**\n",
+    "\n",
+    "The COCO checkpoints are converted from Deci AI's super-gradients releases and remain under\n",
+    "the [Super Gradients Model EULA](https://github.com/Deci-AI/super-gradients/blob/master/LICENSE.YOLONAS.md),\n",
+    "which is **non-commercial use only**. This trips people up constantly, because the\n",
+    "super-gradients *code* is Apache-2.0 and it is easy to assume the weights inherit that.\n",
+    "They do not.\n",
+    "\n",
+    "For a commercial deployment, train from scratch on your own data (see `yolonas train`).\n",
+    "This notebook uses the pretrained weights for demonstration only."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "install-md",
+   "metadata": {},
+   "source": [
+    "## 1. Install\n",
+    "\n",
+    "Requires **Python 3.13+**. Uncomment whichever line matches your setup."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "install-code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install modern-yolonas matplotlib\n",
+    "\n",
+    "# Optional extras:\n",
+    "#   %pip install \"modern-yolonas[onnx]\"      # ONNX export\n",
+    "#   %pip install \"modern-yolonas[openvino]\"  # OpenVINO export\n",
+    "#\n",
+    "# With uv (faster):\n",
+    "#   !uv pip install modern-yolonas matplotlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "version-check",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import modern_yolonas\n",
+    "\n",
+    "print(f\"modern-yolonas {modern_yolonas.__version__}\")\n",
+    "print(f\"torch          {torch.__version__}\")\n",
+    "print(f\"CUDA available {torch.cuda.is_available()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "image-md",
+   "metadata": {},
+   "source": [
+    "## 2. Grab a test image\n",
+    "\n",
+    "A COCO `val2017` frame — two cats asleep on a couch, with two TV remotes next to them.\n",
+    "It is a good smoke test because it exercises three things at once: multiple classes, two\n",
+    "instances of the *same* class (so NMS has to keep both), and one small object (the\n",
+    "remotes) alongside one very large one (the couch)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "download-image",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import urllib.request\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# COCO val2017, image id 000000039769\n",
+    "IMAGE_URL = \"http://images.cocodataset.org/val2017/000000039769.jpg\"\n",
+    "image_path = Path(\"cats.jpg\")\n",
+    "\n",
+    "if not image_path.exists():\n",
+    "    urllib.request.urlretrieve(IMAGE_URL, image_path)\n",
+    "\n",
+    "print(f\"{image_path} — {image_path.stat().st_size / 1024:.0f} KB\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "detect-md",
+   "metadata": {},
+   "source": [
+    "## 3. Detect\n",
+    "\n",
+    "`Detector` wraps the whole pipeline — load → preprocess → forward → NMS → rescale boxes\n",
+    "back to original image coordinates.\n",
+    "\n",
+    "The first call downloads the checkpoint from the Hugging Face Hub and caches it, so it is\n",
+    "slow once and fast forever after. **You will see a licence warning** — that is the EULA\n",
+    "note from the top of this notebook, printed deliberately."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "detect-run",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from modern_yolonas import Detector\n",
+    "\n",
+    "device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
+    "\n",
+    "det = Detector(\"yolo_nas_s\", device=device, conf_threshold=0.25)\n",
+    "result = det(image_path)\n",
+    "\n",
+    "print(f\"{len(result.boxes)} objects detected\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "detect-print",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from modern_yolonas.inference.visualize import COCO_NAMES\n",
+    "\n",
+    "for box, score, class_id in zip(result.boxes, result.scores, result.class_ids):\n",
+    "    x1, y1, x2, y2 = box\n",
+    "    name = COCO_NAMES[int(class_id)]\n",
+    "    print(f\"{name:>10}  {score:.2f}   [{x1:5.0f}, {y1:5.0f}, {x2:5.0f}, {y2:5.0f}]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "result-md",
+   "metadata": {},
+   "source": [
+    "### What came back\n",
+    "\n",
+    "`result` is a `Detection` dataclass holding three parallel numpy arrays:\n",
+    "\n",
+    "| Attribute | Shape | Meaning |\n",
+    "|---|---|---|\n",
+    "| `result.boxes` | `[D, 4]` | `x1, y1, x2, y2` in **original image pixels** |\n",
+    "| `result.scores` | `[D]` | confidence in `[0, 1]` |\n",
+    "| `result.class_ids` | `[D]` | COCO-80 class index |\n",
+    "\n",
+    "`D` is however many boxes survived NMS — it is not a fixed size, and it changes with\n",
+    "`conf_threshold`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "result-shapes",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"boxes     {result.boxes.shape}  {result.boxes.dtype}\")\n",
+    "print(f\"scores    {result.scores.shape}  {result.scores.dtype}\")\n",
+    "print(f\"class_ids {result.class_ids.shape}  {result.class_ids.dtype}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "viz-md",
+   "metadata": {},
+   "source": [
+    "## 4. Visualize\n",
+    "\n",
+    "`result.visualize()` returns an annotated **BGR** numpy array (OpenCV convention), so flip\n",
+    "the channel order before handing it to matplotlib."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "viz-run",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "annotated_bgr = result.visualize()\n",
+    "\n",
+    "plt.figure(figsize=(10, 7))\n",
+    "plt.imshow(annotated_bgr[:, :, ::-1])  # BGR -> RGB\n",
+    "plt.axis(\"off\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "# Or straight to disk:\n",
+    "# result.save(\"output.jpg\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "threshold-md",
+   "metadata": {},
+   "source": [
+    "### The threshold is a dial, not a setting\n",
+    "\n",
+    "`conf_threshold` decides how much marginal evidence you are willing to accept. Drop it and\n",
+    "you buy recall with precision — extra boxes appear, and the low-scoring ones are usually\n",
+    "wrong. Worth running once so you can see the trade-off rather than take it on faith."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "threshold-sweep",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for conf in (0.50, 0.25, 0.10, 0.05):\n",
+    "    r = det(image_path, conf_threshold=conf)\n",
+    "    names = [COCO_NAMES[int(c)] for c in r.class_ids]\n",
+    "    print(f\"conf={conf:.2f} -> {len(r.boxes):2d} boxes  {names}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "lowlevel-md",
+   "metadata": {},
+   "source": [
+    "## 5. Under the hood\n",
+    "\n",
+    "The `Detector` is a convenience wrapper. The model itself is an ordinary `nn.Module` you\n",
+    "can call directly — useful for batching, custom postprocessing, or wiring YOLO-NAS into a\n",
+    "larger pipeline.\n",
+    "\n",
+    "YOLO-NAS is **anchor-free**: it predicts one box per feature-map cell, across three\n",
+    "detection levels at strides 8, 16 and 32. At 640×640 that is\n",
+    "\n",
+    "$$\\left(\\tfrac{640}{8}\\right)^2 + \\left(\\tfrac{640}{16}\\right)^2 + \\left(\\tfrac{640}{32}\\right)^2\n",
+    "= 80^2 + 40^2 + 20^2 = 6400 + 1600 + 400 = 8400$$\n",
+    "\n",
+    "predictions — which is exactly the middle dimension you will see below. The `assert` at the\n",
+    "end is there to make the point rather than to guard anything."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "lowlevel-run",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from modern_yolonas import yolo_nas_s\n",
+    "\n",
+    "model = yolo_nas_s(pretrained=True).eval().to(device)\n",
+    "\n",
+    "x = torch.randn(1, 3, 640, 640, device=device)\n",
+    "with torch.no_grad():\n",
+    "    pred_boxes, pred_scores = model(x)\n",
+    "\n",
+    "print(f\"pred_boxes  {tuple(pred_boxes.shape)}   x1y1x2y2, pixel coords\")\n",
+    "print(f\"pred_scores {tuple(pred_scores.shape)}   per-class probabilities\")\n",
+    "\n",
+    "n_params = sum(p.numel() for p in model.parameters())\n",
+    "print(f\"\\nparameters  {n_params / 1e6:.2f}M\")\n",
+    "\n",
+    "assert pred_boxes.shape[1] == 80**2 + 40**2 + 20**2 == 8400"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "lowlevel-note",
+   "metadata": {},
+   "source": [
+    "Note there is **no objectness score** and **no NMS** at this level — the raw head emits\n",
+    "8400 candidate boxes with 80 class probabilities each, and it is `postprocess()` that\n",
+    "filters them down to the handful you saw in step 3."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "video-md",
+   "metadata": {},
+   "source": [
+    "## 6. Video\n",
+    "\n",
+    "Two options — write an annotated file directly, or iterate frames and do your own thing\n",
+    "with each result. (Not executed here; point it at a video you have.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "video-code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Option 1 — annotate straight to a file\n",
+    "# stats = det.detect_video_to_file(\"input.mp4\", \"output.mp4\")\n",
+    "# print(f\"{stats['total_detections']} detections over {stats['total_frames']} frames\")\n",
+    "\n",
+    "# Option 2 — iterate, for custom per-frame logic (tracking, counting, alerting)\n",
+    "# for frame_idx, frame_result in det.detect_video(\"input.mp4\"):\n",
+    "#     print(f\"frame {frame_idx}: {len(frame_result.boxes)} objects\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "export-md",
+   "metadata": {},
+   "source": [
+    "## 7. Export for deployment\n",
+    "\n",
+    "ONNX and OpenVINO exports are available from both Python and the CLI. These need the\n",
+    "matching extra installed (`modern-yolonas[onnx]` / `modern-yolonas[openvino]`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "export-code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !yolonas export --model yolo_nas_s --format onnx     --output yolo_nas_s.onnx\n",
+    "# !yolonas export --model yolo_nas_s --format openvino --output yolo_nas_s.xml\n",
+    "\n",
+    "# Frigate NVR target — bakes preprocessing AND NMS into the graph, so the exported\n",
+    "# model takes raw uint8 BGR in and emits a flat [D, 7] tensor:\n",
+    "#   [batch, x1, y1, x2, y2, confidence, class_id]\n",
+    "# !yolonas export --model yolo_nas_s --format openvino --target frigate --input-size 320"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "next-md",
+   "metadata": {},
+   "source": [
+    "## Where to go next\n",
+    "\n",
+    "| Task | Command |\n",
+    "|---|---|\n",
+    "| Detect on a folder | `yolonas detect --model yolo_nas_s --source images/ --output results/` |\n",
+    "| Fine-tune on your data | `yolonas train --model yolo_nas_s --data ./dataset --format yolo --epochs 100` |\n",
+    "| Evaluate on COCO | `yolonas eval --model yolo_nas_s --data ./coco --split val2017` |\n",
+    "| Benchmark latency | `yolonas benchmark --model yolo_nas_s` |\n",
+    "\n",
+    "Model variants. Parameter counts are measured with\n",
+    "`sum(p.numel() for p in model.parameters())`; the mAP column is Deci's **published**\n",
+    "figure, which this project has not independently re-measured.\n",
+    "\n",
+    "| Model | Params (measured) | Input | mAP (published) |\n",
+    "|---|---|---|---|\n",
+    "| `yolo_nas_s` | 19.05M | 640 | 47.5 |\n",
+    "| `yolo_nas_m` | 51.18M | 640 | 51.5 |\n",
+    "| `yolo_nas_l` | 66.98M | 640 | 52.2 |\n",
+    "\n",
+    "- Full docs: [`docs/`](../docs/index.md)\n",
+    "- Runnable scripts: [`examples/`](../examples/)\n",
+    "- Architecture walkthrough: [`docs/architecture.md`](../docs/architecture.md)\n",
+    "\n",
+    "And once more, because it is the thing people miss: **the pretrained COCO weights are\n",
+    "non-commercial.** Train from scratch for anything you intend to ship."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/modern_yolonas/hub.py
+++ b/src/modern_yolonas/hub.py
@@ -15,6 +15,7 @@ def from_hub(
     num_classes: int = 80,
     filename: str = "model.safetensors",
     revision: str | None = None,
+    strict: bool = True,
 ) -> nn.Module:
     """Load a YOLO-NAS model from Hugging Face Hub.
 
@@ -24,15 +25,29 @@ def from_hub(
         num_classes: Number of classes in the checkpoint.
         filename: Checkpoint filename in the repository.
         revision: Git revision (branch, tag, or commit hash).
+        strict: Require the checkpoint to match the architecture exactly. Set to
+            ``False`` only when you intend a partial load — e.g. reusing a backbone
+            under a differently-shaped head. A non-strict load leaves any unmatched
+            parameter at its initial value, and the model will still run.
 
     Returns:
         Loaded YoloNAS model.
+
+    Raises:
+        RuntimeError: If ``strict`` and the checkpoint does not match the architecture.
+            Usually means ``variant`` or ``num_classes`` is wrong for this checkpoint.
     """
     from modern_yolonas.model import YoloNAS
+    from modern_yolonas.weights import filter_loadable
 
     path = hf_hub_download(repo_id=repo_id, filename=filename, revision=revision)
     model = YoloNAS.from_config(variant, num_classes=num_classes)
-    model.load_state_dict(load_file(path), strict=False)
+
+    sd = load_file(path)
+    if not strict:
+        sd, _ = filter_loadable(sd, model)
+
+    model.load_state_dict(sd, strict=strict)
     return model
 
 

--- a/src/modern_yolonas/weights.py
+++ b/src/modern_yolonas/weights.py
@@ -71,6 +71,23 @@ def _download(variant: str, repo_id: str, revision: str | None) -> str:
     return hf_hub_download(repo_id=repo_id, filename=WEIGHT_FILES[variant], revision=revision)
 
 
+def filter_loadable(sd: dict[str, torch.Tensor], model: nn.Module) -> tuple[dict[str, torch.Tensor], list[str]]:
+    """Keep only checkpoint entries that match the model in both key and shape.
+
+    ``load_state_dict(..., strict=False)`` tolerates missing and unexpected keys but
+    still raises on a shape mismatch, so dropping the mismatched entries here is what
+    makes a partial load actually work — notably when ``num_classes`` differs from the
+    checkpoint's and the classification heads are a different shape.
+
+    Returns:
+        The filtered state dict, and the sorted names of entries dropped for shape.
+    """
+    model_sd = model.state_dict()
+    kept = {k: v for k, v in sd.items() if k in model_sd and v.shape == model_sd[k].shape}
+    mismatched = sorted(k for k, v in sd.items() if k in model_sd and v.shape != model_sd[k].shape)
+    return kept, mismatched
+
+
 def load_pretrained(
     model: nn.Module,
     variant: str,
@@ -83,7 +100,9 @@ def load_pretrained(
     Args:
         model: A ``YoloNAS`` instance (or any nn.Module with matching keys).
         variant: One of ``"yolo_nas_s"``, ``"yolo_nas_m"``, ``"yolo_nas_l"``.
-        strict: Require exact key matching.
+        strict: Require exact key matching. Pass ``False`` for a partial load — e.g.
+            fine-tuning with a different ``num_classes``, where the classification
+            heads cannot be reused and stay at their initial values.
         repo_id: HF Hub repo (default :data:`HF_REPO_ID`, overridable via the
             ``YOLONAS_HF_REPO`` env var or this arg).
         revision: Git ref (branch / tag / commit) of the repo.
@@ -95,8 +114,18 @@ def load_pretrained(
     raw_sd = load_file(path)
     sd = remap_state_dict(raw_sd)
 
-    model_keys = set(model.state_dict().keys())
-    sd = {k: v for k, v in sd.items() if k in model_keys}
+    if strict:
+        model_keys = set(model.state_dict().keys())
+        sd = {k: v for k, v in sd.items() if k in model_keys}
+    else:
+        sd, mismatched = filter_loadable(sd, model)
+        if mismatched:
+            logger.info(
+                "Skipped %d checkpoint tensor(s) whose shape differs from the model "
+                "(e.g. %s); these keep their initial values.",
+                len(mismatched),
+                ", ".join(mismatched[:3]),
+            )
 
     model.load_state_dict(sd, strict=strict)
     return model

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -2,10 +2,12 @@
 
 import torch
 
+from modern_yolonas.model import YoloNAS
 from modern_yolonas.weights import (
     HF_REPO_ID,
     WEIGHT_FILES,
     _strip_prefix,
+    filter_loadable,
     remap_state_dict,
 )
 
@@ -77,3 +79,55 @@ class TestWeightFiles:
 
     def test_default_repo_id(self):
         assert "/" in HF_REPO_ID
+
+
+class TestFilterLoadable:
+    def test_keeps_matching_entries(self):
+        model = YoloNAS.from_config("yolo_nas_s", num_classes=80)
+        kept, mismatched = filter_loadable(model.state_dict(), model)
+        assert kept.keys() == model.state_dict().keys()
+        assert mismatched == []
+
+    def test_drops_unknown_keys(self):
+        model = YoloNAS.from_config("yolo_nas_s", num_classes=80)
+        sd = {"not.a.real.key": torch.randn(4)}
+        kept, mismatched = filter_loadable(sd, model)
+        assert kept == {}
+        # An unknown key is not a shape mismatch — it is simply absent.
+        assert mismatched == []
+
+    def test_reports_shape_mismatches(self):
+        model = YoloNAS.from_config("yolo_nas_s", num_classes=80)
+        key = "heads.head1.cls_pred.weight"
+        sd = {key: torch.randn(3, 64, 1, 1)}
+        kept, mismatched = filter_loadable(sd, model)
+        assert kept == {}
+        assert mismatched == [key]
+
+
+class TestPartialLoadAcrossNumClasses:
+    """Regression: a checkpoint with a different ``num_classes`` must load partially.
+
+    ``load_state_dict(strict=False)`` tolerates missing/unexpected keys but still
+    raises on a shape mismatch, so the reshaped classification heads have to be
+    dropped before loading. This is the documented fine-tuning path.
+    """
+
+    def test_partial_load_succeeds_and_transfers_backbone(self):
+        pretrained_sd = YoloNAS.from_config("yolo_nas_s", num_classes=80).state_dict()
+        model = YoloNAS.from_config("yolo_nas_s", num_classes=3)
+
+        stem = "backbone.stem.conv.branch_3x3.conv.weight"
+        before = model.state_dict()[stem].clone()
+
+        kept, mismatched = filter_loadable(pretrained_sd, model)
+        model.load_state_dict(kept, strict=False)
+
+        # The reshaped heads were skipped, the backbone was not.
+        assert any("cls_pred" in k for k in mismatched)
+        assert stem not in mismatched
+        assert torch.equal(model.state_dict()[stem], pretrained_sd[stem])
+        assert not torch.equal(model.state_dict()[stem], before)
+
+        # Head keeps its new class count, still at initialization.
+        assert model.state_dict()["heads.head1.cls_pred.weight"].shape[0] == 3


### PR DESCRIPTION
## Summary

- **Bug fix:** non-strict weight loading did not work across a changed `num_classes` — the fine-tuning path documented in `docs/guides/extending.md` raised `RuntimeError`. Also defaults `from_hub(strict=...)` to `True`.
- **Docs fix:** the variant tables understated the parameter count of every model (S/M/L).
- **New:** `notebooks/quickstart.ipynb`, an executed end-to-end walkthrough.

## Details

### 1. Non-strict loading across `num_classes` (bug)

`load_state_dict(strict=False)` tolerates missing and unexpected keys but **still raises on a shape mismatch**. Changing `num_classes` reshapes the classification heads, so this documented path raised for every `num_classes != 80`:

```python
model = YoloNAS.from_config("yolo_nas_s", num_classes=5)
load_pretrained(model, "yolo_nas_s", strict=False)  # RuntimeError
```

Added `weights.filter_loadable()`, which keeps only entries matching the model in both key and shape, used for non-strict loads in `load_pretrained()` and `from_hub()`. Strict loading is unchanged and still requires an exact match.

Verified the backbone genuinely receives pretrained weights while the reshaped heads stay at their initial values — the partial load does the right thing, not merely "does not raise".

`from_hub(strict=...)` now defaults to `True`. It was `False`, so a mismatched checkpoint silently returned a partly-random model that still ran.

`transfer_to()` (added on `main` while this was in progress) is now documented as the **preferred** route for a custom class set, since it loads backbone and neck strictly and cannot silently skip anything. The partial load remains the documented alternative. Confirmed `transfer_to()` is not regressed by this change.

### 2. Parameter counts

Measured with `sum(p.numel() for p in model.parameters())`:

| Variant | Was | Now | Published spec |
|---|---|---|---|
| S | ~12M | **19.05M** | 19.02M |
| M | ~31M | **51.18M** | 51.1M |
| L | ~44M | **66.98M** | 66.98M |

Corrected in `README.md`, `docs/index.md`, `docs/architecture.md`, `docs/getting-started.md`, with a note that params are measured while the mAP column is Deci's published figure this project has not independently re-measured.

### 3. Quickstart notebook

Install, detect, visualize, a confidence-threshold sweep, the raw 8400-anchor model output, and export. Outputs stripped in the committed copy.

It leads with the weight licence, which is the thing people miss: the code is MIT, but the COCO checkpoints derive from super-gradients and remain under the Super Gradients Model EULA (non-commercial only).

## Test Plan

Verified after rebasing onto the latest `main`:

- [x] Existing tests pass — **162 passed, 1 skipped**
- [x] Lint passes — `ruff check src/ tests/` clean; touched files pass `ruff format --check`
- [x] New tests added — 4 network-free regression tests (`TestFilterLoadable`, `TestPartialLoadAcrossNumClasses`)

Additionally:

- Notebook re-executed end to end with `allow_errors=False` against the rebased code — identical output
- Parameter counts re-measured against the rebased code — unchanged
- Both load paths re-checked post-rebase: partial load for `num_classes` 3 and 5, strict load for S/M/L, and upstream `transfer_to()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)