### PR TITLE
Fix inference channel order: feed RGB, not BGR (+3.4 mAP)

### DIFF
--- a/src/modern_yolonas/inference/preprocess.py
+++ b/src/modern_yolonas/inference/preprocess.py
@@ -59,7 +59,13 @@ def preprocess(image: np.ndarray, target_size: int = 640) -> tuple[Tensor, float
         (tensor [1,3,H,W] float32, scale, (pad_left, pad_top))
     """
     padded, scale, pad = letterbox(image, target_size)
-    # HWC → CHW, [0,255] → [0,1] (keep BGR — model was trained on BGR)
-    img = padded.transpose(2, 0, 1).astype(np.float32) / 255.0
-    tensor = torch.from_numpy(img).unsqueeze(0)
+    # BGR → RGB, HWC → CHW, [0,255] → [0,1].
+    #
+    # The channel swap is required: the weights expect RGB. Training feeds RGB
+    # (``data.transforms.Normalize``) and the Frigate export swaps channels in-graph,
+    # so inference is the only path that has to do it here. Measured on COCO val2017
+    # with yolo_nas_s: RGB gives 0.4761 mAP@0.50:0.95 (matching the published 47.5),
+    # BGR gives 0.4420 — a 3.4-point loss.
+    img = padded[:, :, ::-1].transpose(2, 0, 1).astype(np.float32) / 255.0
+    tensor = torch.from_numpy(np.ascontiguousarray(img)).unsqueeze(0)
     return tensor, scale, pad

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -8,6 +8,35 @@ from modern_yolonas.inference.preprocess import letterbox, preprocess
 from modern_yolonas.inference.postprocess import postprocess, rescale_boxes
 
 
+class TestPreprocessChannelOrder:
+    """Regression: ``preprocess`` must hand the model RGB, not BGR.
+
+    The weights expect RGB — training normalizes to RGB and the Frigate export swaps
+    channels in-graph. Feeding BGR costs 3.4 mAP on COCO val2017 (0.4420 vs 0.4761
+    for yolo_nas_s), and it degrades quietly rather than failing, so only a test
+    catches it.
+    """
+
+    def test_swaps_bgr_input_to_rgb_tensor(self):
+        # Distinct per-channel values in OpenCV's BGR order.
+        blue, green, red = 10, 120, 240
+        bgr = np.zeros((640, 640, 3), dtype=np.uint8)
+        bgr[:, :, 0], bgr[:, :, 1], bgr[:, :, 2] = blue, green, red
+
+        tensor, _, _ = preprocess(bgr, 640)
+
+        # Sample the image interior; letterbox pads the border with 114.
+        channels = tensor[0, :, 320, 320]
+        assert channels[0] == pytest.approx(red / 255.0, abs=1e-3), "channel 0 must be R"
+        assert channels[1] == pytest.approx(green / 255.0, abs=1e-3), "channel 1 must be G"
+        assert channels[2] == pytest.approx(blue / 255.0, abs=1e-3), "channel 2 must be B"
+
+    def test_output_is_contiguous(self):
+        # The channel swap introduces a negative stride, which torch.from_numpy rejects.
+        tensor, _, _ = preprocess(np.zeros((480, 640, 3), dtype=np.uint8), 640)
+        assert tensor.is_contiguous()
+
+
 class TestPreprocess:
     def test_letterbox_square(self):
         img = np.random.randint(0, 255, (640, 640, 3), dtype=np.uint8)


### PR DESCRIPTION
## Summary

- `preprocess()` fed the model the OpenCV **BGR** array unchanged; the weights expect **RGB**.
- Costs **3.4 mAP** on COCO val2017. The fixed path reproduces the published YOLO-NAS-S number (47.5) to +0.001.
- The rest of the library already fed RGB — this path was the lone outlier.

## Details

### The library disagreed with itself

| Path | Channel order |
|---|---|
| Training — `data/transforms.py:410` | `image[:, :, ::-1]  # BGR → RGB` → **RGB** |
| Frigate export — `export/frigate.py` | in-graph `Gather([2, 1, 0])` → **RGB** |
| **Python inference — `inference/preprocess.py`** | **BGR** ← the outlier |

A model exported for Frigate and the Python API returned different results for the same image. The old comment read *"keep BGR — model was trained on BGR"*; training in this very repo normalizes to RGB.

### Measured

Full COCO val2017, 5000 images, `yolo_nas_s`, conf 0.001, pycocotools. Everything held identical except the channel order of the input array:

| Channel order | mAP@0.50:0.95 | mAP@0.50 | detections | vs published 47.5 |
|---|---|---|---|---|
| BGR (before) | 0.4420 | 0.6003 | 1,192,564 | −3.30 pts |
| **RGB (after)** | **0.4761** | **0.6458** | 1,211,950 | **+0.11 pts** |

Re-running the ordinary `Detector` path after the fix gives **0.4761**, confirming end to end. A 500-image pass pointed the same way beforehand (0.4884 → 0.5245).

### Why it went unnoticed

super-gradients trained YOLO-NAS with `DetectionRGB2BGR(prob=0.5)` — a random channel-swap augmentation. The model is therefore partly robust to either order, so the wrong one degrades accuracy quietly instead of producing visibly broken output.

## Test Plan

- [x] Existing tests pass — **164 passed, 1 skipped**
- [x] Lint passes — `ruff check src/ tests/` clean; `preprocess.py` format-clean
- [x] New tests added — `TestPreprocessChannelOrder`: asserts tensor channel 0 is red, and that the output is contiguous (the swap introduces a negative stride that `torch.from_numpy` rejects)

Also verified: full COCO val2017 re-run through the ordinary `Detector` path post-fix = **0.4761 mAP**.

## Note for downstream users

Any accuracy measured through the Python `Detector` before this commit is understated by roughly 3 mAP. Latency is unaffected — the swap is a view plus one contiguous copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)